### PR TITLE
update shell regex (spotify app no longer opening)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,6 +35,9 @@
     "withGlobalTauri": true
   },
   "plugins": {
+    "shell": {
+      "open": "^https?://.+|^ebb://.+|^spotify:.+"
+    },
     "deep-link": {
       "desktop": {
         "schemes": ["ebb"]


### PR DESCRIPTION
Recent Tauri shell [update 2.2.1](https://github.com/tauri-apps/plugins-workspace/blob/v2/plugins/shell/CHANGELOG.md) broke opening the Spotify app, which is required per their guidelines. This fixes it.